### PR TITLE
bug: fix channel not found in table

### DIFF
--- a/bin/connect-random.sh
+++ b/bin/connect-random.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker exec -it "$(docker ps -q | shuf -n1)" sh

--- a/bin/run-cluster.sh
+++ b/bin/run-cluster.sh
@@ -11,7 +11,8 @@ networkname="camomilenet"
 networkprefix="172.22.0"
 port="8118"
 
-docker network create --subnet="$networkprefix.0/16" "$networkname" 2>&1
+docker build . -t dhtnode:latest
+docker network create --subnet="$networkprefix.0/16" "$networkname" >/dev/null
 
 set -e
 

--- a/bin/run-node.sh
+++ b/bin/run-node.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 set -euo pipefail
 
 menum=$1

--- a/cmd/dhtnode/main.go
+++ b/cmd/dhtnode/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -113,6 +114,13 @@ func main() {
 			Address: *nodeAddress,
 		}
 	}
+
+	// Log line file:linenumber.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	// Prefix log output with "[<NodeID>]".
+	shortID := me.NodeID.String()[:6]
+	colorID := me.NodeID[0]
+	log.SetPrefix(fmt.Sprintf("[\033[38;5;%dm%s\033[0m] ", colorID, shortID))
 
 	log.Printf("My node ID is: %v", me.NodeID)
 

--- a/network/table.go
+++ b/network/table.go
@@ -12,7 +12,6 @@ type findNodesTable struct {
 func newFindNodesTable() *findNodesTable {
 	return &findNodesTable{
 		items: make(map[SessionID]chan Result),
-		Mutex: sync.Mutex{},
 	}
 }
 
@@ -42,7 +41,6 @@ type findValueTable struct {
 func newFindValueTable() *findValueTable {
 	return &findValueTable{
 		items: make(map[SessionID]chan Result),
-		Mutex: sync.Mutex{},
 	}
 }
 
@@ -72,7 +70,6 @@ type pingTable struct {
 func newPingTable() *pingTable {
 	return &pingTable{
 		items: make(map[SessionID]chan *PingResult),
-		Mutex: sync.Mutex{},
 	}
 }
 


### PR DESCRIPTION
 * Channels were inserted after sending. So if there were enough waiting
   processes on the locks on the table the response would come back
   before the channel had been added.
 * Add better logging with Node ID.

Fixes: #51 