### PR TITLE
dht+network+node: node.(ID).Bytes() must return a copy of bytes

### DIFF
--- a/dht/dht.go
+++ b/dht/dht.go
@@ -233,6 +233,7 @@ func (dht *DHT) walk(call Call) ([]route.Contact, error) {
 
 			ch, err := call.Do(nw, contact.Address)
 			if err != nil {
+				log.Println(err)
 				sl.Remove(contact)
 			} else {
 				// Mark as contacted.
@@ -330,6 +331,7 @@ func (dht *DHT) iterativeStore(value string) (hash store.Key, err error) {
 func (dht *DHT) iterativeFindValue(hash store.Key) (value string, err error) {
 	call := NewFindValueCall(hash)
 	closest, err := dht.walk(call)
+
 	if err != nil {
 		return
 	}

--- a/network/network.go
+++ b/network/network.go
@@ -242,7 +242,7 @@ func (u *udpNetwork) SendValue(key store.Key, value string, closest []route.Cont
 
 	for _, c := range contacts {
 		p := &packet.NodeInfo{
-			NodeId: c.NodeID[:],
+			NodeId: c.NodeID.Bytes(),
 			Ip:     c.Address.IP,
 			Port:   uint32(c.Address.Port),
 		}
@@ -275,13 +275,10 @@ func (u *udpNetwork) SendValue(key store.Key, value string, closest []route.Cont
 
 func (u *udpNetwork) SendNodes(closest []route.Contact, sessionID SessionID, addr net.UDPAddr) error {
 	var nodes []*packet.NodeInfo
-	var contacts []route.Contact
 
-	contacts = append(contacts, closest...)
-
-	for _, c := range contacts {
+	for _, c := range closest {
 		p := &packet.NodeInfo{
-			NodeId: c.NodeID[:],
+			NodeId: c.NodeID.Bytes(),
 			Ip:     c.Address.IP,
 			Port:   uint32(c.Address.Port),
 		}

--- a/node/node.go
+++ b/node/node.go
@@ -57,9 +57,11 @@ func IDFromBytes(b []byte) (id ID) {
 	return
 }
 
-// Bytes returns the bytes slice without a fixed size for a node ID.
+// Bytes returns a copy of the bytes slice without a fixed size for a node ID.
 func (n ID) Bytes() []byte {
-	return n[:]
+	b := make([]byte, IDBytesLength)
+	copy(b, n[:])
+	return b
 }
 
 // Equal compares the node ID with another.


### PR DESCRIPTION
 * Before a reference was returned every time, if this was put in a loop
   the last value would be overwritten on every loop (and all other
   values that share the same reference).