### PR TITLE
network+bin: fix session timeouts and use super node instead

### DIFF
--- a/bin/do-random.sh
+++ b/bin/do-random.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+randomnode="$(docker ps -q | shuf -n1)"
+docker exec "$randomnode" "$@"

--- a/bin/run-cluster.sh
+++ b/bin/run-cluster.sh
@@ -28,9 +28,9 @@ genhash() {
     printf "%s" "$1" | sha256sum | cut -f1 -d' '
 }
 
-lastnum="$numnodes"
-lastip="$networkprefix.$((numnodes+1))"
-lastid=$(genhash "$lastnum")
+bootnum="1"
+bootip="$networkprefix.2"
+bootid=$(genhash "$bootnum")
 
 # Start N nodes and pair them.
 for num in $(seq 1 "$numnodes")
@@ -43,11 +43,7 @@ do
     echo "Starting node: #$num, $nodeid@$nodeip:$port"
     docker run --net "$networkname" --ip "$nodeip" -t -d \
         dhtnode "$num" "$nodeid" "$nodeip:$port" \
-                "$lastid" "$lastip:$port" >/dev/null &
-
-    lastnum="$num"
-    lastid="$nodeid"
-    lastip="$nodeip"
+                "$bootid" "$bootip:$port" >/dev/null &
 done
 
 printf "Waiting for all nodes to finish starting up... "

--- a/network/network.go
+++ b/network/network.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"crypto/rand"
+	"encoding/hex"
 	"net"
 	"time"
 
@@ -119,10 +120,7 @@ type FindValueRequest struct {
 
 func NewUDPNetwork(me route.Contact) (Network, error) {
 	fvtTicker := time.NewTicker(time.Second)
-	defer fvtTicker.Stop()
-
 	fntTicker := time.NewTicker(time.Second)
-	defer fntTicker.Stop()
 
 	n := &udpNetwork{
 		me:  me,
@@ -564,4 +562,8 @@ func (u *udpNetwork) send(addr net.UDPAddr, packet packet.Packet) error {
 		return err
 	}
 	return nil
+}
+
+func (id SessionID) String() string {
+	return hex.EncodeToString(id[:])
 }

--- a/network/table.go
+++ b/network/table.go
@@ -3,6 +3,8 @@ package network
 import (
 	"sync"
 	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 type item struct {
@@ -27,6 +29,7 @@ func newTable(ttl time.Duration, ticker *time.Ticker) *table {
 			t.Lock()
 			for k, v := range t.items {
 				if now.After(v.ttl) {
+					log.Debug().Msgf("Session timed out (ID: %v)", k)
 					v.result <- nil // Signal removal of channel.
 					delete(t.items, k)
 				}


### PR DESCRIPTION
I accidentally stopped the tickers when creating a new network instance... Woops.

Also changed so that the cluster uses a single super node during start up.